### PR TITLE
added deployed subgraph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ Aims to deliver analytics & historical data for SushiSwap. Still a work in progr
 
 The Graph exposes a GraphQL endpoint to query the events and entities within the SushiSwap ecosytem.
 
-Currently there is only a single subgraph, but additional subgraphs can be added to this repo:
+Currently there are two subgraphs, but additional subgraphs can be added to this repo:
 
 1. **SushiSwap**: Currently only has support for current MasterChef and MasterChefPool data: https://thegraph.com/explorer/subgraph/sushiswap/sushiswap
+
+2. **SushiSwap-SubGraph-Fork** (on uniswap-fork branch): Indexes the SushiSwap Factory, includes Price Data, Pricing, etc: https://thegraph.com/explorer/subgraph/zippoxer/sushiswap-subgraph-fork
+
 
 ## To setup and deploy
 


### PR DESCRIPTION
The branch should be explained in the README, as it refers to a different SubGraph currently used in production.