### PR TITLE
Fix xSushiBar bug with xSushiAge and subgraph codegen and build error

### DIFF
--- a/src/bar.ts
+++ b/src/bar.ts
@@ -233,6 +233,8 @@ export function transfer(event: TransferEvent): void {
 
     user.xSushiAgeDestroyed = user.xSushiAgeDestroyed.plus(xSushiAgeDestroyed)
 
+    // remove xSushiAge
+    user.xSushiAge = user.xSushiAge.minus(xSushiAgeDestroyed);
     // Update xSushi last
     user.xSushi = user.xSushi.minus(value)
 

--- a/src/exchange/pricing.ts
+++ b/src/exchange/pricing.ts
@@ -91,7 +91,7 @@ export function getEthPrice(block: ethereum.Block = null): BigDecimal {
 }
 
 export function findEthPerToken(token: Token): BigDecimal {
-  if (token.id == WETH_ADDRESS) {
+  if (Address.fromString(token.id) == WETH_ADDRESS) {
     return BIG_DECIMAL_ONE
   }
 

--- a/subgraphs/bar.yaml
+++ b/subgraphs/bar.yaml
@@ -20,11 +20,11 @@ dataSources:
         - User
       abis:
         - name: Bar
-          file: ../node_modules/@sushiswap/core/build/contracts/SushiBar.json
+          file: ../node_modules/@sushiswap/core/build/abi/SushiBar.json
         - name: SushiToken
-          file: ../node_modules/@sushiswap/core/build/contracts/SushiToken.json
+          file: ../node_modules/@sushiswap/core/build/abi/SushiToken.json
         - name: Pair
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Pair.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Pair.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: transfer

--- a/subgraphs/dexcandles.yaml
+++ b/subgraphs/dexcandles.yaml
@@ -20,7 +20,7 @@ dataSources:
         - Pair
       abis:
         - name: Factory
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Factory.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Factory.json
       eventHandlers:
         - event: PairCreated(indexed address,indexed address,address,uint256)
           handler: handleNewPair
@@ -39,7 +39,7 @@ templates:
         - Pair
       abis:
         - name: Pair
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Pair.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Pair.json
       eventHandlers:
         - event: Swap(indexed address,uint256,uint256,uint256,uint256,indexed address)
           handler: handleSwap

--- a/subgraphs/exchange.yaml
+++ b/subgraphs/exchange.yaml
@@ -20,13 +20,13 @@ dataSources:
         - Factory
       abis:
         - name: Factory
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Factory.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Factory.json
         - name: Pair
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Pair.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Pair.json
         - name: SushiToken
-          file: ../node_modules/@sushiswap/core/build/contracts/SushiToken.json
+          file: ../node_modules/@sushiswap/core/build/abi/SushiToken.json
         - name: ERC20
-          file: ../node_modules/@sushiswap/core/build/contracts/ERC20.json
+          file: ../node_modules/@sushiswap/core/build/abi/ERC20.json
         - name: ERC20SymbolBytes
           file: ../abis/ERC20SymbolBytes.json
         - name: ERC20NameBytes
@@ -59,9 +59,9 @@ templates:
         - User
       abis:
         - name: Pair
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Pair.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Pair.json
         - name: Factory
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Factory.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Factory.json
       eventHandlers:
         - event: Mint(indexed address,uint256,uint256)
           handler: onMint

--- a/subgraphs/lockup.yaml
+++ b/subgraphs/lockup.yaml
@@ -21,9 +21,9 @@ dataSources:
         - User
       abis:
         - name: MasterChef
-          file: ../node_modules/@sushiswap/core/build/contracts/MasterChef.json
+          file: ../node_modules/@sushiswap/core/build/abi/MasterChef.json
         - name: Pair
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Pair.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Pair.json
       eventHandlers:
         - event: Deposit(indexed address,indexed uint256,uint256)
           handler: deposit

--- a/subgraphs/maker.yaml
+++ b/subgraphs/maker.yaml
@@ -21,11 +21,11 @@ dataSources:
         - Serving
       abis:
         - name: Pair
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Pair.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Pair.json
         - name: ERC20
-          file: ../node_modules/@sushiswap/core/build/contracts/ERC20.json
+          file: ../node_modules/@sushiswap/core/build/abi/ERC20.json
         - name: Factory
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Factory.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Factory.json
       eventHandlers:
         - event: Swap(indexed address,uint256,uint256,uint256,uint256,indexed address)
           handler: served

--- a/subgraphs/masterchef.yaml
+++ b/subgraphs/masterchef.yaml
@@ -23,13 +23,13 @@ dataSources:
         - User
       abis:
         - name: MasterChef
-          file: ../node_modules/@sushiswap/core/build/contracts/MasterChef.json
+          file: ../node_modules/@sushiswap/core/build/abi/MasterChef.json
         - name: Factory
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Factory.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Factory.json
         - name: Pair
-          file: ../node_modules/@sushiswap/core/build/contracts/UniswapV2Pair.json
+          file: ../node_modules/@sushiswap/core/build/abi/UniswapV2Pair.json
         - name: ERC20
-          file: ../node_modules/@sushiswap/core/build/contracts/ERC20.json
+          file: ../node_modules/@sushiswap/core/build/abi/ERC20.json
       eventHandlers:
         - event: Deposit(indexed address,indexed uint256,uint256)
           handler: deposit

--- a/subgraphs/timelock.yaml
+++ b/subgraphs/timelock.yaml
@@ -20,7 +20,7 @@ dataSources:
         - Timelock
       abis:
         - name: Timelock
-          file: ../node_modules/@sushiswap/core/build/contracts/Timelock.json
+          file: ../node_modules/@sushiswap/core/build/abi/Timelock.json
       eventHandlers:
         - event: CancelTransaction(indexed bytes32,indexed address,uint256,string,bytes,uint256)
           handler: canceledTransaction


### PR DESCRIPTION
- Fixes #34 : user xSushiAge was not being properly updated when user was burning xSushi
- Fixes #35 : added cast to compare between string and address
- Fixes new bug introduced by  hardhat config and changing directory structure (https://github.com/sushiswap/sushiswap/blob/fe73eb779a97627a048e1d1d3f87e10a88a3f15b/hardhat.config.js#L24-L29) which was making codegen failing